### PR TITLE
Sync master branch with upstream using github actions

### DIFF
--- a/.github/workflows/upstream_sync.yml
+++ b/.github/workflows/upstream_sync.yml
@@ -1,0 +1,22 @@
+# This pipeline keeps the master branch up to date with upstream master
+name: Upstream Synchronization
+
+on:
+  schedule:
+  - cron:  "*/15 * * * *"
+  workflow_dispatch:
+
+jobs:
+  repo-sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        persist-credentials: false
+    - name: repo-sync
+      uses: repo-sync/github-sync@v2
+      with:
+        source_repo: "https://github.com/PX4/PX4-Autopilot.git"
+        source_branch: "master"
+        destination_branch: "master"
+        github_token: ${{ secrets.PAT }}


### PR DESCRIPTION
**Describe problem solved by this pull request**
Upstream is moving faster than we develop internally in the lab, and this can lead to large differences when not being in sync with upstream. This can lead to incompetence of the private fork, and makes it hard to maintain the diff. Therefore it is important to make the diff visible and obvious so that we can selectively merge changes from upstream.

**Describe your solution**
This commit adds a github actions pipeline that syncs the `master` branch of this repo with upstream every 15 minutes

**Test data / coverage**
Just wait 15 minutes after merging :smile:  tested on [personal fork](https://github.com/Jaeyoung-Lim/Firmware/actions/runs/552482297)

**Additional context**
- This follows the devOps proposal in https://docs.google.com/document/d/1xeVwPA0NtiarI9ZSSgAAld8An2wVsZFg8a2QGyTrtGg/edit?usp=sharing
- The default branch was switched to `develop` in order to keep the lab default branch a bit more stable