### PR TITLE
[WIP] Fix adis16448 not starting

### DIFF
--- a/src/drivers/imu/adis16448/ADIS16448.cpp
+++ b/src/drivers/imu/adis16448/ADIS16448.cpp
@@ -468,9 +468,9 @@ ADIS16448::measure()
 
 	// checksum
 	if (report.CRC16 != ComputeCRC16((uint16_t *)&report.DIAG_STAT)) {
-		perf_count(_perf_crc_bad);
-		perf_end(_perf_read);
-		return -EIO;
+		// perf_count(_perf_crc_bad);
+		// perf_end(_perf_read);
+		// return -EIO;
 	}
 
 	// error count


### PR DESCRIPTION
**Describe problem solved by this pull request**
I have finally figured out why our imu won't start with the upstream PX4 adis16448 driver.
Here is what I found
- There has been CRC checks added in between our private PX4 and upstream PX4. The failure comes from a CRC check in 

https://github.com/PX4/PX4-Autopilot/blob/a002a07ed52897dfd1082100b0af24f9b247916e/src/drivers/imu/adis16448/ADIS16448.cpp#L470-L474

- This is because the IMU we are using is ADIS16448AMLZ. In 2015, the datasheet was updated to ADIS16448BMLZ, which included the burst read CRC functionality. (Check [datasheet](https://www.analog.com/media/en/technical-documentation/data-sheets/adis16448.pdf)) It seems like you cannot do CRC checks on ADIS16448AMLZ although it is not explicitly stated.
- All our vehicles seem to use the ADIS16448AMLZ.

**Describe your solution**
Disabling the CRC checks result in the imu drivers working / reading properly. In this PR, I have commented the CRC checks out.

I don't think the current state should be merged as it is, but not sure how we can work around this problem yet

**Describe possible alternatives**
It would be "nicer" if we could detect whether the imu plugged in is either `ADIS16448AMLZ` or `ADIS16448BMLZ`
In principle it should be better to have the CRC checks available, but since we can't replace all the IMUs, probably specifying manually to disable CRC checks could be an option

**Test data / coverage**
Connect to the mavlink shell (e.g. `Tools/mavlink_shell.py`)
```
adis16448 -S start
```

**Additional context**
- Upstream issue: https://github.com/PX4/PX4-Autopilot/issues/16839
- Thanks @weixuanzhang for helping on debugging the issue!
- @tstastny Is there anyway that there are ADIS16448BMLZ imus that are available in the lab? 