### PR TITLE
Allow building rotorS simulator as part of PX4 SITL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,3 +66,6 @@
 [submodule "src/drivers/uavcannode_gps_demo/libcanard"]
 	path = src/drivers/uavcannode_gps_demo/libcanard
 	url = https://github.com/UAVCAN/libcanard
+[submodule "Tools/rotors_simulator"]
+	path = Tools/rotors_simulator
+	url = https://github.com/ethz-asl/rotors_simulator.git

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -27,6 +27,7 @@ px4_add_git_submodule(TARGET git_gazebo PATH "${PX4_SOURCE_DIR}/Tools/sitl_gazeb
 px4_add_git_submodule(TARGET git_jmavsim PATH "${PX4_SOURCE_DIR}/Tools/jMAVSim")
 px4_add_git_submodule(TARGET git_flightgear_bridge PATH "${PX4_SOURCE_DIR}/Tools/flightgear_bridge")
 px4_add_git_submodule(TARGET git_jsbsim_bridge PATH "${PX4_SOURCE_DIR}/Tools/jsbsim_bridge")
+px4_add_git_submodule(TARGET git_rotors_simulator PATH "${PX4_SOURCE_DIR}/Tools/rotors_simulator")
 
 # Add support for external project building
 include(ExternalProject)
@@ -88,8 +89,22 @@ ExternalProject_Add(jsbsim_bridge
 	BUILD_ALWAYS 1
 )
 
+ExternalProject_Add(rotors_simulator
+	SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/rotors_simulator/rotors_gazebo_plugins
+	CMAKE_ARGS
+		-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DNO_ROS=TRUE
+	BINARY_DIR ${PX4_BINARY_DIR}/build_rotors_simulator
+	INSTALL_COMMAND ""
+	DEPENDS
+		git_rotors_simulator
+	USES_TERMINAL_CONFIGURE true
+	USES_TERMINAL_BUILD true
+	EXCLUDE_FROM_ALL true
+	BUILD_ALWAYS 1
+)
+
 # create targets for each viewer/model/debugger combination
-set(viewers none jmavsim gazebo)
+set(viewers none jmavsim gazebo rotors)
 set(debuggers none ide gdb lldb ddd valgrind callgrind)
 set(models none shell
 	if750a iris iris_dual_gps iris_opt_flow iris_opt_flow_mockup iris_vision iris_rplidar iris_irlock iris_ctrlalloc iris_obs_avoid iris_rtps px4vision solo typhoon_h480
@@ -135,6 +150,8 @@ foreach(viewer ${viewers})
 					list(APPEND all_posix_vmd_make_targets ${_targ_name})
 					if (viewer STREQUAL "gazebo")
 						add_dependencies(${_targ_name} px4 sitl_gazebo)
+					elseif(viewer STREQUAL "rotors")
+						add_dependencies(${_targ_name} px4 rotors_simulator)
 					elseif(viewer STREQUAL "jmavsim")
 						add_dependencies(${_targ_name} px4 git_jmavsim)
 					endif()


### PR DESCRIPTION
**Describe problem solved by this pull request**
This is more of a proposal on integrating rotorS into PX4 SITL. Please feel free to point out what is problematic on trying to do what this PR is doing. 

Although rotorS has a option to build without ROS, this option is currently broken and the primary use case involves running it with ROS. While ROS is a useful tool for experimenting with models, this breaks the SITL use case, where we want to simulate a configuration that will be used on a real vehicle (simulating FMU + Companion computer setup). 

Even if you can build rotorS simulator without ROS, it is cumbersome to run it with the PX4 SITL instance

**Describe your solution**
This adds `rotors_simulator` as a submodule of this repository and allows you to build rotors as part of the px4 SITL make target

For example you can build rotors with PX4 with
```
make px4_sitl rotors
```


**Describe possible alternatives**
- We can add convenience scripts on the rotors_simulator side to essentially do the same thing, and run SITL but the HIL interface is tightly coupled with the firmware so I think it makes it easier to have it as a submodule. (e.g. PX4-SITL_Gazebo is also a submodule)
- 

**Test data / coverage**
Run
```
make px4_sitl rotors
```

**Additional context**
- Currently this is marked as a draft PR since the rotors_simulator `NO_ROS` build option is broken. I would need to fix that first before this is merged.