### PR TITLE
Start ADIS16448 IMU for easyglider through parameter

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/22000_asl_easyglider
+++ b/ROMFS/px4fmu_common/init.d/airframes/22000_asl_easyglider
@@ -43,6 +43,8 @@ then
 
     # set disarmed value for the ESC
     param set PWM_DISARMED 1000
+
+    param set-default SENS_EN_ADIS164X 1
 fi
 
 set MIXER asl_easyglider

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -108,6 +108,12 @@ then
 	vl53l1x start -X
 fi
 
+# ADIS16448 spi external IMU
+if param compare -s SENS_EN_ADIS164X 1
+then
+	adis16448 -S start
+fi
+
 # probe for optional external I2C devices
 if param compare SENS_EXT_I2C_PRB 1
 then

--- a/src/drivers/imu/analog_devices/adis16448/parameters.c
+++ b/src/drivers/imu/analog_devices/adis16448/parameters.c
@@ -1,0 +1,44 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Analog Devices ADIS16448 IMU (external SPI)
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 1
+ * @group Sensors
+ * @value 0 Disabled
+ * @value 1 Enabled
+  */
+PARAM_DEFINE_INT32(SENS_EN_ADIS164X, 0);


### PR DESCRIPTION
**Describe problem solved by this pull request**
This commit adds starting the `adis16448` imu driver for the easyglider.

**Describe your solution**
This is done by the following.
- Add a parameter that enables the `adis16448` through a parameter `SENS_EN_ADIS164X` (`SENS_EN_ADIS16448` is too long, so I had to add the `X`)
- Add the parameter to enable the imu in the easyglider aiframe config

**Test data / coverage**
Tested with the adis16448 attached to a pixhawk4

**Additional context**
- Upstream PR for the parameter based initialization from https://github.com/PX4/PX4-Autopilot/pull/17313
- A missing piece is specifying the rotation of the external IMU through parameters
