### PR TITLE
Build rotorS mavlink interface with PX4 mavlink

### DIFF
--- a/.github/workflows/rotors_tests.yml
+++ b/.github/workflows/rotors_tests.yml
@@ -1,0 +1,55 @@
+name: RotorS PX4 Build Test
+
+on:
+  push:
+    branches:
+    - 'master'
+  pull_request:
+    branches:
+    - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+        - 'px4io/px4-dev-simulation-bionic:2020-11-18' # Gazebo 9
+    container:
+      image: ${{ matrix.container }}
+      options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        token: ${{ secrets.ACCESS_TOKEN }}
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      shell: cmake -P {0}
+      run: |
+        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+        message("::set-output name=timestamp::${current_date}")
+    - name: ccache cache files
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: rotors_tests-RelWithDebInfo-ccache-${{steps.ccache_cache_timestamp.outputs.timestamp}}
+        restore-keys: rotors_tests-RelWithDebInfo-ccache-
+    - name: setup ccache
+      run: |
+          mkdir -p ~/.ccache
+          echo "base_dir = ${GITHUB_WORKSPACE}" > ~/.ccache/ccache.conf
+          echo "compression = true" >> ~/.ccache/ccache.conf
+          echo "compression_level = 5" >> ~/.ccache/ccache.conf
+          echo "max_size = 100M" >> ~/.ccache/ccache.conf
+          ccache -s
+          ccache -z
+    - name: Install glog
+      run: apt update && apt install -y libgoogle-glog-dev libyaml-cpp-dev
+    - name: Build PX4 RotorS
+      env:
+        PX4_CMAKE_BUILD_TYPE: RelWithDebInfo
+        DONT_RUN: 1
+      run: make px4_sitl rotors
+    - name: ccache post-run px4/firmware
+      run: ccache -s

--- a/.gitmodules
+++ b/.gitmodules
@@ -63,3 +63,6 @@
 [submodule "src/drivers/uavcannode_gps_demo/libcanard"]
 	path = src/drivers/uavcannode_gps_demo/libcanard
 	url = https://github.com/UAVCAN/libcanard
+[submodule "Tools/rotors_simulator"]
+	path = Tools/rotors_simulator
+	url = https://github.com/ethz-asl/rotors_simulator.git

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -85,11 +85,29 @@ ExternalProject_Add(jsbsim_bridge
 	BUILD_ALWAYS 1
 )
 
+px4_add_git_submodule(TARGET git_rotors PATH "${PX4_SOURCE_DIR}/Tools/rotors_simulator")
+ExternalProject_Add(rotors_simulator
+	SOURCE_DIR ${PX4_SOURCE_DIR}/Tools/rotors_simulator/rotors_gazebo_plugins
+	CMAKE_ARGS
+		-DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+		-DNO_ROS=true
+	BINARY_DIR ${PX4_BINARY_DIR}/build_rotors
+	INSTALL_COMMAND ""
+	DEPENDS
+		git_rotors
+	USES_TERMINAL_CONFIGURE true
+	USES_TERMINAL_BUILD true
+	EXCLUDE_FROM_ALL true
+	BUILD_ALWAYS 1
+	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> -- -j1
+)
+
 # create targets for each viewer/model/debugger combination
 set(viewers
 	none
 	jmavsim
 	gazebo
+	rotors
 )
 
 set(debuggers
@@ -178,6 +196,8 @@ foreach(viewer ${viewers})
 						add_dependencies(${_targ_name} px4 sitl_gazebo)
 					elseif(viewer STREQUAL "jmavsim")
 						add_dependencies(${_targ_name} px4 git_jmavsim)
+					elseif(viewer STREQUAL "rotors")
+						add_dependencies(${_targ_name} px4 rotors_simulator)
 					endif()
 				else()
 					if(viewer STREQUAL "gazebo")


### PR DESCRIPTION
**Describe problem solved by this pull request**
Running PX4 and [rotors_simulator](https://github.com/ethz-asl/rotors_simulator) with SITL/HITL has been painful due to the convoluted mavlink depdendency.

The problem can be described as the following.
- PX4 has a mavlink [c_library_v2](https://github.com/mavlink/c_library_v2) submodule that is generated by upstream [mavlink](https://github.com/mavlink/mavlink). This is continuously updated with the PX4 Autopilot Firmware
- When running in ROS, mavros / rotorS use a different mavlink which is distributed by the [mavros](https://github.com/mavlink/mavros) maintainers called [mavlink_gbp_release](https://github.com/mavlink/mavlink-gbp-release). The problem is that `mavlink_gbp_release` is only released every month(specifically, when the month and date numbers match - e.g. 4th of April) and mavros only updates whenever there is a new update on mavlink. Therefore, this mavlink for mavros is **ALWAYS OUTDATED**.
- Since mavros does not have a HIL interface, a mavlink update on the firmware side will breaks on the HIL side. Since rotorS is assuming the correct mavlink version is what mavros is using, this failure occurs silently. When we realize that there is a breakage on HIL, it is very hard to backtrack when it has been broken since it is probably a few months prior. (couple hundred to thousand commits behind in PX4).

The result is a huge :exploding_head: 

**Describe your solution**
This PR adds the [rotors_simulator](https://github.com/ethz-asl/rotors_simulator) as a submodule of PX4, and build rotorS as part of the PX4 SITL toolchain. 
![image](https://user-images.githubusercontent.com/5248102/113832112-940a9500-9788-11eb-8545-bbb087efaba8.png)

This allows us to use the mavlink inside PX4 when building the rotorS `mavlink_interface` so that we can verify rotorS builds with the mavlink inside PX4 (up-to-date mavlink).

We still can't deal with the fact that mavros is using an outdated mavlink version, but we can at least detect it whenever it happens on the firmware side, and deal with it :smiley: 

**Test data / coverage**
You can test the build with the following command
```
DONT_RUN=1 make px4_sitl rotors
```

**Additional context**
- This PR depends on a change on the rotorS side: https://github.com/ethz-asl/rotors_simulator/pull/665
- @david-rohr Since you are working with SITL on rotorS, I think we can try to unify our efforts here so we can make sure SITL always works with our flavour of PX4