### PR TITLE
Specify ADIS16448 IMU rotation

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/22000_asl_easyglider
+++ b/ROMFS/px4fmu_common/init.d/airframes/22000_asl_easyglider
@@ -45,6 +45,7 @@ then
     param set PWM_DISARMED 1000
 
     param set-default SENS_EN_ADIS164X 1
+    param set SENS_EN_ADIS164X 4
 fi
 
 set MIXER asl_easyglider

--- a/ROMFS/px4fmu_common/init.d/rc.sensors
+++ b/ROMFS/px4fmu_common/init.d/rc.sensors
@@ -111,7 +111,14 @@ fi
 # ADIS16448 spi external IMU
 if param compare -s SENS_EN_ADIS164X 1
 then
-	adis16448 -S start
+	if param compare -s SENS_OR_ADIS164X 0
+	then
+		adis16448 -S start
+	fi
+	if param compare -s SENS_OR_ADIS164X 4
+	then
+		adis16448 -S start -R 4
+	fi
 fi
 
 # Hall effect sensors si7210

--- a/src/drivers/imu/analog_devices/adis16448/parameters.c
+++ b/src/drivers/imu/analog_devices/adis16448/parameters.c
@@ -42,3 +42,15 @@
  * @value 1 Enabled
   */
 PARAM_DEFINE_INT32(SENS_EN_ADIS164X, 0);
+
+/**
+ * Analog Devices ADIS16448 IMU Orientation(external SPI)
+ *
+ * @reboot_required true
+ * @min 0
+ * @max 101
+ * @group Sensors
+ * @value 0 ROTATION_NONE
+ * @value 4 ROTATION_YAW_180
+  */
+PARAM_DEFINE_INT32(SENS_OR_ADIS164X, 0);


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously it was not possible to persistently start the adis16448 orientation persistently depending on the vehicle. 

**Describe your solution**
This commit adds a parameter to the adis16448 driver so that the orientation of the sensor can be specified

**Test data / coverage**
- Tested with a Pixhawk4 and a ADIS16448AMLZ attached to the external SPI

**Additional context**
- Upstream: https://github.com/PX4/PX4-Autopilot/pull/17812
