### PR TITLE
Add airflow_slip and airflow_aoa to rtps message definitions

### DIFF
--- a/msg/tools/uorb_rtps_message_ids.yaml
+++ b/msg/tools/uorb_rtps_message_ids.yaml
@@ -344,6 +344,10 @@ rtps:
     id: 159
   - msg: sensor_hall
     id: 160
+  - msg: airflow_aoa
+    id: 161
+  - msg: airflow_slip
+    id: 162
   ########## multi topics: begin ##########
   - msg: actuator_controls_0
     id: 170


### PR DESCRIPTION
**Describe problem solved by this pull request**
CI has been failing since the `airflow_slip` and `airflow_aoa` uORB messages had not been exposed in the rtps message definitions. The messages were added in https://github.com/ethz-asl/ethzasl_fw_px4/pull/17

**Describe your solution**
Append the `airflow_slip` and `airflow_aoa` definitions to the rtps message definitions with a new ID

**Test data / coverage**
CI passes!

**Additional context**
- This will likely introduce conflicts whenever there is a new uORB message upstream. Therefore we probably want to upstream this for the future.