### PR TITLE
Add ASL Believer airframe config

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/22003_asl_believer
+++ b/ROMFS/px4fmu_common/init.d/airframes/22003_asl_believer
@@ -1,0 +1,52 @@
+#!/bin/sh
+#
+# @name Autonomous Systems Lab, ETH Zurich Believer
+#
+# @type Plane V-Tail
+# @class Plane
+#
+# @output MAIN1 aileron right
+# @output MAIN2 aileron left
+# @output MAIN3 v-tail right
+# @output MAIN4 v-tail left
+# @output MAIN5 throttle
+# @output MAIN6 wheel
+# @output MAIN7 flaps right
+# @output MAIN8 flaps left
+#
+# @output AUX1 feed-through of RC AUX1 channel
+# @output AUX2 feed-through of RC AUX2 channel
+# @output AUX3 feed-through of RC AUX3 channel
+#
+# @maintainer Jaeyoung Lim <jalim@ethz.ch>
+#
+# @board px4_fmu-v2 exclude
+# @board bitcraze_crazyflie exclude
+#
+
+. ${R}etc/init.d/rc.fw_defaults
+
+param set-default FW_AIRSPD_MIN 10
+param set-default FW_AIRSPD_TRIM 15
+param set-default FW_AIRSPD_MAX 20
+
+param set-default FW_MAN_P_MAX 55
+param set-default FW_MAN_R_MAX 55
+param set-default FW_R_LIM 55
+
+param set-default FW_WR_FF 0.2
+param set-default FW_WR_I 0.2
+param set-default FW_WR_IMAX 0.8
+param set-default FW_WR_P 1
+param set-default FW_W_RMAX 0
+
+# set disarmed value for the ESC
+param set-default PWM_MAIN_DISARM 1000
+
+# The Mini Talon does not have a wheel and
+# no flaps. I leave them here because the mixer
+# computes also wheel and flap controls.
+set MIXER AAVVTWFF_vtail
+
+# use PWM parameters for throttle channel
+set PWM_OUT 5

--- a/ROMFS/px4fmu_common/init.d/airframes/22003_asl_believer
+++ b/ROMFS/px4fmu_common/init.d/airframes/22003_asl_believer
@@ -46,7 +46,7 @@ param set-default PWM_MAIN_DISARM 1000
 # The Mini Talon does not have a wheel and
 # no flaps. I leave them here because the mixer
 # computes also wheel and flap controls.
-set MIXER AAVVTWFF_vtail
+set MIXER AAVVTTFF_vtail
 
 # use PWM parameters for throttle channel
 set PWM_OUT 5

--- a/ROMFS/px4fmu_common/init.d/airframes/22003_asl_believer
+++ b/ROMFS/px4fmu_common/init.d/airframes/22003_asl_believer
@@ -42,6 +42,8 @@ param set-default FW_W_RMAX 0
 
 # set disarmed value for the ESC
 param set-default PWM_MAIN_DISARM 1500
+param set-default PWM_MAIN_DIS5 900
+param set-default PWM_MAIN_DIS6 900
 
 # The Mini Talon does not have a wheel and
 # no flaps. I leave them here because the mixer
@@ -49,4 +51,4 @@ param set-default PWM_MAIN_DISARM 1500
 set MIXER AAVVTTFF_vtail
 
 # use PWM parameters for throttle channel
-set PWM_OUT 5
+set PWM_OUT 56

--- a/ROMFS/px4fmu_common/init.d/airframes/22003_asl_believer
+++ b/ROMFS/px4fmu_common/init.d/airframes/22003_asl_believer
@@ -41,7 +41,7 @@ param set-default FW_WR_P 1
 param set-default FW_W_RMAX 0
 
 # set disarmed value for the ESC
-param set-default PWM_MAIN_DISARM 1000
+param set-default PWM_MAIN_DISARM 1500
 
 # The Mini Talon does not have a wheel and
 # no flaps. I leave them here because the mixer

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -161,6 +161,7 @@ px4_add_romfs_files(
 	22000_asl_easyglider
 	22001_asl_techpod
 	22002_asl_sensesoar2
+	22003_asl_believer
 
 	24001_dodeca_cox
 

--- a/ROMFS/px4fmu_common/mixers/AAVVTTFF_vtail.main.mix
+++ b/ROMFS/px4fmu_common/mixers/AAVVTTFF_vtail.main.mix
@@ -1,0 +1,61 @@
+Aileron/v-tail/throttle/wheel/flaps mixer for PX4FMU
+=======================================================
+
+This file defines mixers suitable for controlling a fixed wing aircraft with
+aileron, v-tail (rudder, elevator), throttle, steerable wheel and flaps
+using PX4FMU.
+The configuration assumes the aileron servos are connected to PX4FMU servo
+output 0 and 1, the tail servos to output 2 and 3, the throttle
+to output 4, the wheel to output 5 and the flaps to output 6 and 7.
+
+Inputs to the mixer come from channel group 0 (vehicle attitude), channels 0
+(roll), 1 (pitch), 2 (yaw) and 3 (thrust) 4 (flaps) 6 (flaperon).
+
+Aileron mixer (roll + flaperon)
+---------------------------------
+
+This mixer assumes that the aileron servos are set up mechanically reversed.
+
+M: 2
+S: 0 0 -10000 -10000      0 -10000  10000
+S: 0 6  10000  10000      0 -10000  10000
+
+M: 2
+S: 0 0 -10000 -10000      0 -10000  10000
+S: 0 6 -10000 -10000      0 -10000  10000
+
+V-tail mixers
+-------------
+Three scalers total (output, roll, pitch).
+
+M: 2
+S: 0 2   7000   7000      0 -10000  10000
+S: 0 1  -8000  -8000      0 -10000  10000
+
+M: 2
+S: 0 2   7000   7000      0 -10000  10000
+S: 0 1   8000   8000      0 -10000  10000
+
+Motor speed mixer
+-----------------
+Two scalers total (output, thrust).
+
+This mixer generates a full-range output (-1 to 1) from an input in the (0 - 1)
+range.  Inputs below zero are treated as zero.
+
+M: 1
+S: 0 3      0  20000 -10000 -10000  10000
+
+M: 1
+S: 0 3      0  20000 -10000 -10000  10000
+
+Flaps mixer
+------------
+Flap servos are physically reversed.
+
+M: 1
+S: 0 4      0   5000 -10000 -10000  10000
+
+M: 1
+S: 0 4      0  -5000  10000 -10000  10000
+

--- a/ROMFS/px4fmu_common/mixers/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/mixers/CMakeLists.txt
@@ -35,6 +35,7 @@ px4_add_romfs_files(
 	AAERTWF.main.mix
 	AAVVTWFF.main.mix
 	AAVVTWFF_vtail.main.mix
+	AAVVTTFF_vtail.main.mix
 	AERT.main.mix
 	AETRFG.main.mix
 	babyshark.main.mix


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR adds the airframe config  and mixer files for the ETHZ ASL Believer

The existing mixer had to be extended so that it can run two motors at once.
There are no differential thrust modeled in yet. 

**Test data / coverage**
- Bench testing on the real aircraft. (No flight testing yet)
![ezgif com-gif-maker (12)](https://user-images.githubusercontent.com/5248102/128237330-35cdb5ab-b370-4418-83bf-060b18ede396.gif)

- Flight testing
planned for 13th of August