### PR TITLE
Pr believer sitl

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# @name Plane SITL
+#
+
+. ${R}etc/init.d/rc.fw_defaults
+
+param set-default EKF2_ARSP_THR 8
+param set-default EKF2_FUSE_BETA 1
+param set-default EKF2_MAG_ACCLIM 0
+param set-default EKF2_MAG_YAWLIM 0
+
+param set-default FW_LND_AIRSPD_SC 1
+param set-default FW_LND_ANG 8
+param set-default FW_THR_LND_MAX 0
+
+param set-default FW_L1_PERIOD 12
+
+param set-default FW_MAN_P_MAX 30
+
+param set-default FW_PR_I 0.4
+param set-default FW_PR_P 0.9
+param set-default FW_PR_FF 0.2
+param set-default FW_PSP_OFF 2
+param set-default FW_P_LIM_MAX 32
+param set-default FW_P_LIM_MIN -15
+
+param set-default FW_RR_FF 0.1
+param set-default FW_RR_P 0.3
+
+param set-default FW_THR_MAX 0.6
+param set-default FW_THR_MIN 0.05
+param set-default FW_THR_CRUISE 0.25
+
+param set-default FW_T_ALT_TC 2
+param set-default FW_T_CLMB_MAX 8
+param set-default FW_T_HRATE_FF 0.5
+param set-default FW_T_SINK_MAX 2.7
+param set-default FW_T_SINK_MIN 2.2
+param set-default FW_T_TAS_TC 2
+
+param set-default FW_W_EN 1
+
+param set-default MIS_LTRMIN_ALT 30
+param set-default MIS_TAKEOFF_ALT 30
+
+param set-default NAV_ACC_RAD 15
+param set-default NAV_DLL_ACT 2
+param set-default NAV_LOITER_RAD 50
+
+param set-default RWTO_TKOFF 1
+
+set MIXER_FILE etc/mixers-sitl/plane_sitl.main.mix
+set MIXER custom

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
@@ -50,5 +50,7 @@ param set-default NAV_LOITER_RAD 50
 
 param set-default RWTO_TKOFF 1
 
+param set-default FW_USE_NPFG 1
+
 set MIXER_FILE etc/mixers-sitl/plane_sitl.main.mix
 set MIXER custom

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -62,6 +62,7 @@ px4_add_romfs_files(
 	1034_rascal-electric
 	1035_techpod
 	1036_malolo
+	1037_believer
 	1040_standard_vtol
 	1041_tailsitter
 	1042_tiltrotor

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -120,6 +120,7 @@ set(debuggers
 
 set(models
 	none
+	believer
 	boat
 	cloudship
 	if750a

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -500,6 +500,8 @@ FixedwingPositionControl::status_publish()
 		npfg_status.adapted_period = _npfg.getAdaptedPeriod();
 		npfg_status.p_gain = _npfg.getPGain();
 		npfg_status.time_const = _npfg.getTimeConst();
+		npfg_status.timestamp = hrt_absolute_time();
+		_npfg_status_pub.publish(npfg_status);
 
 	} else {
 		pos_ctrl_status.nav_bearing = _l1_control.nav_bearing();
@@ -507,25 +509,11 @@ FixedwingPositionControl::status_publish()
 		pos_ctrl_status.xtrack_error = _l1_control.crosstrack_error();
 		pos_ctrl_status.acceptance_radius = _l1_control.switch_distance(500.0f);
 
-		npfg_status.lat_accel = 0.0f;
-		npfg_status.lat_accel_ff = 0.0f;
-		npfg_status.heading_ref = 0.0f;
-		npfg_status.bearing = 0.0f;
-		npfg_status.bearing_feas = 0.0f;
-		npfg_status.bearing_feas_on_track = 0.0f;
-		npfg_status.signed_track_error = 0.0f;
-		npfg_status.track_error_bound = 0.0f;
-		npfg_status.airspeed_ref = 0.0f;
-		npfg_status.min_ground_speed_ref = 0.0f;
-		npfg_status.adapted_period = 0.0f;
-		npfg_status.p_gain = 0.0f;
-		npfg_status.time_const = 0.0f;
 	}
 
-	npfg_status.timestamp = hrt_absolute_time();
-
 	_pos_ctrl_status_pub.publish(pos_ctrl_status);
-	_npfg_status_pub.publish(npfg_status);
+
+
 }
 
 void


### PR DESCRIPTION
**Describe problem solved by this pull request**
This adds a SITL Gazebo model for testing the Nonlinear Path Following Guidance (NPFG) for fixedwing vehicles, which was added in https://github.com/ethz-asl/ethzasl_fw_px4/pull/27

- While NPFG is disabled by default, we enable it for the believer SITL aircraft
- Some minor improvements for the NPFG status not being publihsed when disabled
- Logging NPFG uORB topics to the uLog for monitoring


**Test data / coverage**
The model can be tested with wind using the following command
```
make px4_sitl gazebo_believer__windy
```

![image](https://user-images.githubusercontent.com/5248102/135765278-05cd2ced-232e-425f-8358-73de596fcbd0.png)


**Additional context**
- This is a follow up PR of https://github.com/ethz-asl/ethzasl_fw_px4/pull/27
- This PR includes a upstream PR from https://github.com/PX4/PX4-Autopilot/pull/17898