### PR TITLE
Update rotors build test container

### DIFF
--- a/.github/workflows/rotors_tests.yml
+++ b/.github/workflows/rotors_tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         container:
-        - 'px4io/px4-dev-simulation-bionic:2020-11-18' # Gazebo 9
+        - 'px4io/px4-dev-simulation-bionic:2021-09-08' # Gazebo 9
     container:
       image: ${{ matrix.container }}
       options: --privileged --ulimit core=-1 --security-opt seccomp=unconfined


### PR DESCRIPTION
**Describe problem solved by this pull request**
Recently the rotorS build tests have been failing since the firmware requires additonal dependencies to build

**Describe your solution**
This commit updates the rotors build test container version, in order to fix the build tests failing due to missing dependencies


**Test data / coverage**
- This PR passes rotorS build tests
![image](https://user-images.githubusercontent.com/5248102/138354398-ae950b2e-e16e-4316-92d3-94c2967184f6.png)

**Additional Context**
- NuttX targets still failing due to si7210 driver broken on upstream

