### PR TITLE
Create airframe config for EZG

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/22000_asl_easyglider
+++ b/ROMFS/px4fmu_common/init.d/airframes/22000_asl_easyglider
@@ -45,7 +45,84 @@ then
     param set PWM_DISARMED 1000
 
     param set-default SENS_EN_ADIS164X 1
-    param set SENS_EN_ADIS164X 4
+    param set-default SENS_OR_ADIS164X 4
+
+    param set-default EKF2_ARSP_THR 6.0
+    param set-default EKF2_BARO_NOISE 2.0
+    param set-default EKF2_EVP_NOISE 0.05
+    param set-default EKF2_HGT_MODE 1
+
+    param set-default FW_AIRSPD_MAX 16.0
+    param set-default FW_AIRSPD_MIN 8.5
+    param set-default FW_AIRSPD_TRIM 10.0
+    param set-default FW_DTRIM_P_VMAX -0.25
+    param set-default FW_DTRIM_P_VMIN 0.25
+    param set-default FW_GND_SPD_MIN 0.0
+
+    param set-default FW_LND_AIRSPD_SC 1.2
+    param set-default FW_LND_ANG 4.0
+    param set-default FW_LND_EARLYCFG	1
+    param set-default FW_LND_FLALT 0.5
+    param set-default FW_LND_FL_PMAX 5.0
+    param set-default FW_LND_FL_PMIN 0.0
+    param set-default FW_LND_HHDIST 0.0
+    param set-default FW_LND_HVIRT 0.10
+    param set-default FW_LND_TLALT 0.5
+
+    param set-default FW_PR_FF 1.0
+    param set-default FW_PR_I 0.001
+    param set-default FW_PR_IMAX 0.2
+    param set-default FW_PR_P 0.12
+    param set-default FW_P_LIM_MAX 20.0
+    param set-default FW_P_LIM_MIN -15.0
+
+
+    param set-default FW_RLL_TO_YAW_FF 0.1
+    param set-default FW_RR_FF 0.8
+    param set-default FW_RR_I 0.01
+    param set-default FW_RR_IMAX 0.0
+    param set-default FW_RR_P 0.25
+    param set-default FW_R_LIM 35.0
+    param set-default FW_THR_CRUISE 0.45
+    param set-default FW_THR_IDLE 0.0
+    param set-default FW_THR_LND_MAX 0.0
+    param set-default FW_T_CLMB_MAX 3.0
+    param set-default FW_T_HRATE_FF 0.8
+    param set-default FW_T_PTCH_DAMP 0.0
+    param set-default FW_T_RLL2THR 0.0
+
+    param set-default FW_T_SINK_MAX 3.0
+    param set-default FW_T_SINK_MIN 1.2
+    param set-default FW_YR_FF 0.8
+    param set-default FW_YR_I 0.01
+    param set-default FW_YR_IMAX 0.0
+    param set-default FW_YR_P 0.65
+
+    param set-default GPS_2_CONFIG 0
+    param set-default GPS_UBX_MODE 0
+    param set-default LND_FLIGHT_T_HI 2
+    param set-default LND_FLIGHT_T_LO -1126687183
+    param set-default NPFG_GSP_MAX_TK 5.0
+    param set-default NPFG_SW_DST_MLT0.5
+
+    param set-default RWTO_MAX_PITCH 20.0
+    param set-default SDLOG_PROFILE 1
+    param set-default SENS_DPRES_OFF 0.001
+
+    param set-defualt FW_USE_NPFG 1
+
+    param set-default ASPD_SCALE 0.85
+
+    param set-default PWM_MAIN_DIS1 1500
+    param set-default PWM_MAIN_DIS2 1350
+    param set-default PWM_MAIN_DIS3 1500
+    param set-default PWM_MAIN_DIS4 1500
+    param set-default PWM_MAIN_DIS5 -1
+    param set-default PWM_MAIN_DIS6 -1
+    param set-default PWM_MAIN_DISARM 1000
+    param set-default PWM_MAIN_TRIM1 0.0
+    param set-default PWM_MAIN_TRIM2 0.4
+
 fi
 
 set MIXER asl_easyglider


### PR DESCRIPTION
**Describe problem solved by this pull request**
Previously, the parameters for EZGs were stored as a raw param file, making it hard to version the parameter files. Also, this makes it hard to match the parameter with the firmware version.

**Describe your solution**
This PR adds the parameters of our current EZGs to the airframe config. 
- The defaults are defined as the current vehicle paramters. In case we change it, QGC will rightly display non-default parameters.
- Vehicle specific calibration parameters are not added to the airframe config

