### PR TITLE
Add offboard interface for NPFG for direct path tangent and position setpoint

### DIFF
--- a/src/lib/npfg/npfg.cpp
+++ b/src/lib/npfg/npfg.cpp
@@ -577,6 +577,27 @@ void NPFG::navigateLoiter(const Vector2d &loiter_center, const Vector2d &vehicle
 	updateRollSetpoint();
 } // navigateLoiter
 
+
+void NPFG::navigatePathTangent(const matrix::Vector2d &vehicle_pos, const matrix::Vector2d &position_setpoint,
+			       const matrix::Vector2f &tangent_setpoint,
+			       const matrix::Vector2f &ground_vel, const matrix::Vector2f &wind_vel, const float &curvature)
+{
+	path_type_loiter_ = true;
+
+	// set unit tangent directly
+	unit_path_tangent_ = tangent_setpoint;
+
+	// positive in direction of path normal
+	matrix::Vector2f error_vector = getLocalPlanarVector(position_setpoint, vehicle_pos);
+	signed_track_error_ = -1.0f * matrix::sign(curvature) * error_vector.norm();
+
+	float path_curvature = -1.0f * curvature;
+
+	evaluate(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, path_curvature);
+
+	updateRollSetpoint();
+} // navigatePathTangent
+
 void NPFG::navigateHeading(float heading_ref, const Vector2f &ground_vel, const Vector2f &wind_vel)
 {
 	path_type_loiter_ = false;

--- a/src/lib/npfg/npfg.cpp
+++ b/src/lib/npfg/npfg.cpp
@@ -585,15 +585,14 @@ void NPFG::navigatePathTangent(const matrix::Vector2d &vehicle_pos, const matrix
 	path_type_loiter_ = true;
 
 	// set unit tangent directly
-	unit_path_tangent_ = tangent_setpoint;
+	unit_path_tangent_ = tangent_setpoint.normalized();
 
-	// positive in direction of path normal
+	// closest point to vehicle
 	matrix::Vector2f error_vector = getLocalPlanarVector(position_setpoint, vehicle_pos);
-	signed_track_error_ = -1.0f * matrix::sign(curvature) * error_vector.norm();
+	float track_error_sign = (abs(curvature) < EPSILON) ? 1.0 : matrix::sign(curvature);
+	signed_track_error_ = track_error_sign * cross2D(unit_path_tangent_, error_vector);
 
-	float path_curvature = -1.0f * curvature;
-
-	evaluate(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, path_curvature);
+	evaluate(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, curvature);
 
 	updateRollSetpoint();
 } // navigatePathTangent

--- a/src/lib/npfg/npfg.hpp
+++ b/src/lib/npfg/npfg.hpp
@@ -244,6 +244,22 @@ public:
 			    const matrix::Vector2f &wind_vel);
 
 	/*
+	 * Loitering (unlimited) logic. Takes loiter center, radius, and direction and
+	 * determines the relevant parameters for evaluating the NPFG guidance law,
+	 * then updates control setpoints.
+	 *
+	 * @param[in] loiter_center The position of the center of the loiter circle [m]
+	 * @param[in] vehicle_pos Vehicle position in WGS84 coordinates (lat,lon) [deg]
+	 * @param[in] radius Loiter radius [m]
+	 * @param[in] loiter_direction Loiter direction: -1=counter-clockwise, 1=clockwise
+	 * @param[in] ground_vel Vehicle ground velocity vector [m/s]
+	 * @param[in] wind_vel Wind velocity vector [m/s]
+	 */
+	void navigatePathTangent(const matrix::Vector2d &vehicle_pos, const matrix::Vector2d &position_setpoint,
+				 const matrix::Vector2f &tangent_setpoint,
+				 const matrix::Vector2f &ground_vel, const matrix::Vector2f &wind_vel, const float &curvature);
+
+	/*
 	 * Navigate on a fixed heading.
 	 *
 	 * This only holds a certain (air mass relative) direction and does not perform

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1170,15 +1170,30 @@ FixedwingPositionControl::control_auto_position(const hrt_abstime &now, const Ve
 		_att_sp.yaw_body = _l1_control.nav_bearing();
 	}
 
-	tecs_update_pitch_throttle(now, position_sp_alt,
-				   target_airspeed,
-				   radians(_param_fw_p_lim_min.get()),
-				   radians(_param_fw_p_lim_max.get()),
-				   tecs_fw_thr_min,
-				   tecs_fw_thr_max,
-				   tecs_fw_mission_throttle,
-				   false,
-				   radians(_param_fw_p_lim_min.get()));
+	if (_control_mode.flag_control_offboard_enabled) {
+		tecs_update_pitch_throttle(now, position_sp_alt,
+					   target_airspeed,
+					   radians(_param_fw_p_lim_min.get()),
+					   radians(_param_fw_p_lim_max.get()),
+					   tecs_fw_thr_min,
+					   tecs_fw_thr_max,
+					   tecs_fw_mission_throttle,
+					   false,
+					   radians(_param_fw_p_lim_min.get()),
+					   tecs_status_s::TECS_MODE_NORMAL,
+					   pos_sp_curr.vz);
+
+	} else {
+		tecs_update_pitch_throttle(now, position_sp_alt,
+					   target_airspeed,
+					   radians(_param_fw_p_lim_min.get()),
+					   radians(_param_fw_p_lim_max.get()),
+					   tecs_fw_thr_min,
+					   tecs_fw_thr_max,
+					   tecs_fw_mission_throttle,
+					   false,
+					   radians(_param_fw_p_lim_min.get()));
+	}
 }
 
 void

--- a/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
+++ b/src/modules/fw_pos_control_l1/FixedwingPositionControl.cpp
@@ -1150,7 +1150,16 @@ FixedwingPositionControl::control_auto_position(const hrt_abstime &now, const Ve
 	if (_param_fw_use_npfg.get()) {
 		_npfg.setAirspeedNom(target_airspeed);
 		_npfg.setAirspeedMax(_param_fw_airspd_max.get());
-		_npfg.navigateWaypoints(prev_wp, curr_wp, curr_pos, ground_speed, _wind_vel);
+
+		if (_control_mode.flag_control_offboard_enabled) {
+			// Navigate directly on position setpoint and path tangent
+			matrix::Vector2f velocity_2d(pos_sp_curr.vx, pos_sp_curr.vy);
+			_npfg.navigatePathTangent(curr_pos, curr_wp, velocity_2d.normalized(), ground_speed, _wind_vel, pos_sp_curr.yawspeed);
+
+		} else {
+			_npfg.navigateWaypoints(prev_wp, curr_wp, curr_pos, ground_speed, _wind_vel);
+		}
+
 		_att_sp.roll_body = _npfg.getRollSetpoint();
 		_att_sp.yaw_body = _npfg.getBearing();
 		target_airspeed = _npfg.getAirspeedRef();
@@ -2099,15 +2108,17 @@ FixedwingPositionControl::Run()
 			vehicle_local_position_setpoint_s trajectory_setpoint;
 
 			if (_trajectory_setpoint_sub.update(&trajectory_setpoint)) {
+				bool valid_setpoint = false;
+				_pos_sp_triplet = {}; // clear any existing
+				_pos_sp_triplet.timestamp = trajectory_setpoint.timestamp;
+				_pos_sp_triplet.current.timestamp = trajectory_setpoint.timestamp;
+
 				if (PX4_ISFINITE(trajectory_setpoint.x) && PX4_ISFINITE(trajectory_setpoint.y) && PX4_ISFINITE(trajectory_setpoint.z)) {
 					double lat;
 					double lon;
 
 					if (map_projection_reproject(&_global_local_proj_ref, trajectory_setpoint.x, trajectory_setpoint.y, &lat, &lon) == 0) {
-						_pos_sp_triplet = {}; // clear any existing
 
-						_pos_sp_triplet.timestamp = trajectory_setpoint.timestamp;
-						_pos_sp_triplet.current.timestamp = trajectory_setpoint.timestamp;
 						_pos_sp_triplet.current.valid = true;
 						_pos_sp_triplet.current.type = position_setpoint_s::SETPOINT_TYPE_POSITION;
 						_pos_sp_triplet.current.lat = lat;
@@ -2117,7 +2128,23 @@ FixedwingPositionControl::Run()
 						_pos_sp_triplet.current.cruising_throttle = NAN; // ignored
 					}
 
-				} else {
+					valid_setpoint = true;
+
+				}
+
+				if (PX4_ISFINITE(trajectory_setpoint.vx) && PX4_ISFINITE(trajectory_setpoint.vy)
+				    && PX4_ISFINITE(trajectory_setpoint.vz)) {
+					_pos_sp_triplet.current.vx = trajectory_setpoint.vx;
+					_pos_sp_triplet.current.vy = trajectory_setpoint.vy;
+					_pos_sp_triplet.current.vz = trajectory_setpoint.vz;
+					valid_setpoint = true;
+				}
+
+				if (PX4_ISFINITE(trajectory_setpoint.yawspeed)) {
+					_pos_sp_triplet.current.yawspeed = trajectory_setpoint.yawspeed;
+				}
+
+				if (!valid_setpoint) {
 					mavlink_log_critical(&_mavlink_log_pub, "Invalid offboard setpoint\t");
 					events::send(events::ID("fixedwing_position_control_invalid_offboard_sp"), events::Log::Error,
 						     "Invalid offboard setpoint");

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -72,6 +72,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("manual_control_switches");
 	add_topic("mission_result");
 	add_topic("navigator_mission_item");
+	add_topic("npfg_status", 100);
 	add_topic("offboard_control_mode", 100);
 	add_topic("onboard_computer_status", 10);
 	add_topic("parameter_update");


### PR DESCRIPTION
**Describe problem solved by this pull request**
Calculating closest points to arbitrary paths and the behavior when doing so might be closely related to the planner behavior, therefore beneficial to calculate offline.

**Describe your solution**
This commit adds an interface to pass the path tangent and closest point directly to NPFG using the offboard interface.
- The offboard planner passes the setpoint, path tangent and curvature information over `SET_POSITION_TARGET_LOCAL_NED` where the velocity fields (`vx, vy`) are used to pass the path tangent and `yawspeed` field as curvature
- While this does not pass the desired path just yet, it provides a good opportunity to pass abritrary paths with variable curvature (e.g. clothoids). The offboard planner just needs to calculate the closest point, path tangent and the curvature of the path
- Use height rate setpoints directly to TECS by taking the vertical velocity compnent `vz`

**Test data / coverage**
Tested using the terrain navigation planner
![ezgif com-gif-maker (16)](https://user-images.githubusercontent.com/5248102/139230829-13458b62-f91e-4644-8678-25a4af45b792.gif)

**Additional context**
- This PR is against https://github.com/ethz-asl/ethzasl_fw_px4/pull/34, but will be reopened against `develop` when merged
- Initially I was trying to add a path interface directly and calculate closest points on the fmu. However, I think passing it as offboard setpoints as done in this PR provides a nice middle ground for flexibility and simple implementation