### PR TITLE
Remove unused variable from npfg

### DIFF
--- a/src/lib/npfg/npfg.hpp
+++ b/src/lib/npfg/npfg.hpp
@@ -417,7 +417,6 @@ private:
 	float roll_lim_rad_{math::radians(30.0f)}; // maximum roll angle [rad]
 	float roll_setpoint_{0.0f}; // current roll angle setpoint [rad]
 	float roll_slew_rate_{0.0f}; // roll angle setpoint slew rate limit [rad/s]
-	bool circle_mode_{false}; // true if following circle
 	bool path_type_loiter_{false}; // true if the guidance law is tracking a loiter circle
 
 


### PR DESCRIPTION
**Describe problem solved by this pull request**
There was a variable in npfg that was not being used.

This was introduced in https://github.com/ethz-asl/ethzasl_fw_px4/pull/27

**Additional context**
- This commit fixes the clang tidy check on the build test CI
