### PR TITLE
Add believer SITL Gazebo model

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1037_believer
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# @name Plane SITL
+#
+
+. ${R}etc/init.d/rc.fw_defaults
+
+param set-default EKF2_ARSP_THR 8
+param set-default EKF2_FUSE_BETA 1
+param set-default EKF2_MAG_ACCLIM 0
+param set-default EKF2_MAG_YAWLIM 0
+
+param set-default FW_LND_AIRSPD_SC 1
+param set-default FW_LND_ANG 8
+param set-default FW_THR_LND_MAX 0
+
+param set-default FW_L1_PERIOD 12
+
+param set-default FW_MAN_P_MAX 30
+
+param set-default FW_PR_I 0.4
+param set-default FW_PR_P 0.9
+param set-default FW_PR_FF 0.2
+param set-default FW_PSP_OFF 2
+param set-default FW_P_LIM_MAX 32
+param set-default FW_P_LIM_MIN -15
+
+param set-default FW_RR_FF 0.1
+param set-default FW_RR_P 0.3
+
+param set-default FW_THR_MAX 0.6
+param set-default FW_THR_MIN 0.05
+param set-default FW_THR_CRUISE 0.25
+
+param set-default FW_T_ALT_TC 2
+param set-default FW_T_CLMB_MAX 8
+param set-default FW_T_HRATE_FF 0.5
+param set-default FW_T_SINK_MAX 2.7
+param set-default FW_T_SINK_MIN 2.2
+param set-default FW_T_TAS_TC 2
+
+param set-default FW_W_EN 1
+
+param set-default MIS_LTRMIN_ALT 30
+param set-default MIS_TAKEOFF_ALT 30
+
+param set-default NAV_ACC_RAD 15
+param set-default NAV_DLL_ACT 2
+param set-default NAV_LOITER_RAD 50
+
+param set-default RWTO_TKOFF 1
+
+set MIXER_FILE etc/mixers-sitl/plane_sitl.main.mix
+set MIXER custom

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -62,6 +62,7 @@ px4_add_romfs_files(
 	1034_rascal-electric
 	1035_techpod
 	1036_malolo
+	1037_believer
 	1040_standard_vtol
 	1041_tailsitter
 	1042_tiltrotor

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -120,6 +120,7 @@ set(debuggers
 
 set(models
 	none
+	believer
 	boat
 	cloudship
 	if750a


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR adds a believer SITL Gazebo model

A clear and concise description of what you have implemented.


**Test data / coverage**
```
make px4_sitl gazebo_believer
```

**Additional context**
- This updates the sitl_gazebo submodule including the model