### PR TITLE
Handle nagative curvature properly in NPFG

### DIFF
--- a/src/lib/npfg/npfg.cpp
+++ b/src/lib/npfg/npfg.cpp
@@ -456,8 +456,8 @@ float NPFG::lateralAccelFF(const Vector2f &unit_path_tangent, const Vector2f &gr
 
 	// path frame curvature is the instantaneous curvature at our current distance
 	// from the actual path (considering e.g. concentric circles emanating outward/inward)
-	const float path_frame_curvature = path_curvature / math::max(1.0f - path_curvature * signed_track_error,
-					   path_curvature * MIN_RADIUS);
+	float path_frame_curvature = path_curvature / math::max(1.0f - path_curvature * signed_track_error,
+				     fabsf(path_curvature) * MIN_RADIUS);
 
 	// limit tangent ground speed to along track (forward moving) direction
 	const float tangent_ground_speed = math::max(ground_vel.dot(unit_path_tangent), 0.0f);

--- a/src/modules/logger/logged_topics.cpp
+++ b/src/modules/logger/logged_topics.cpp
@@ -72,6 +72,7 @@ void LoggedTopics::add_default_topics()
 	add_topic("mission");
 	add_topic("mission_result");
 	add_topic("navigator_mission_item");
+	add_topic("npfg_status", 100);
 	add_topic("offboard_control_mode", 100);
 	add_topic("onboard_computer_status", 10);
 	add_topic("parameter_update");


### PR DESCRIPTION
**Describe problem solved by this pull request**
When a negative curvature is being passed, the feedforward acceleration calculation for minimum curvature was being compared as if it was still a positive curvature

**Describe your solution**
This PR fixes this problem by adding an absolute to the check

**Test data / coverage**
Tested with both negative and positive loiter radius

**Additional context**
- Added npfg status logging as default