### PR TITLE
Handle additional case with NPFG waypoint navigation handling

### DIFF
--- a/src/lib/npfg/npfg.cpp
+++ b/src/lib/npfg/npfg.cpp
@@ -507,6 +507,7 @@ void NPFG::navigateWaypoints(const Vector2d &waypoint_A, const Vector2d &waypoin
 
 	Vector2f vector_A_to_B = getLocalPlanarVector(waypoint_A, waypoint_B);
 	Vector2f vector_A_to_vehicle = getLocalPlanarVector(waypoint_A, vehicle_pos);
+	Vector2f vector_B_to_vehicle = getLocalPlanarVector(waypoint_B, vehicle_pos);
 
 	if (vector_A_to_B.norm() < EPSILON) {
 		// the waypoints are on top of each other and should be considered as a
@@ -522,6 +523,14 @@ void NPFG::navigateWaypoints(const Vector2d &waypoint_A, const Vector2d &waypoin
 		unit_path_tangent_ = vector_A_to_B.normalized();
 		signed_track_error_ = cross2D(unit_path_tangent_, vector_A_to_vehicle);
 		evaluate(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, 0.0f, true, -vector_A_to_vehicle.normalized());
+
+	} else if (vector_A_to_B.dot(vector_B_to_vehicle) > 0.0f) {
+		// we are in front of waypoint B, fly directly to it until the bearing generated
+		// to the line segement between B and A is shallower than that from the
+		// bearing to the second waypoint (B).
+		unit_path_tangent_ = -vector_A_to_B.normalized();
+		signed_track_error_ = cross2D(unit_path_tangent_, vector_B_to_vehicle);
+		evaluate(ground_vel, wind_vel, unit_path_tangent_, signed_track_error_, 0.0f, true, -vector_B_to_vehicle.normalized());
 
 	} else {
 		// track the line segment between A and B


### PR DESCRIPTION
**Describe problem solved by this pull request**
The NPFG waypoint handling logic did not handle the case when the vehicle was further along the line segment and passed the current waypoint.

This resulted in the vehicle continuing along the line segment defined by the previous(Waypoint A) and current waypoint(Waypoint B) even though the vehicle has passed the current waypoint (Waypoint B).

This can happen when the current waypoint altitude difference is big, so that the vehicle switches to a loiter setpoint to climb, and then switches back to a considering it as a position setpoint only after when it has passed the current waypoint.

My guess is that this was hidden since we never had position waypoints that were consecutively on different altitudes. 

**Describe your solution**
This PR adds additional case handling of the navigate waypoints in NPFG

**Test data / coverage**
Tested in SITL Gazebo
```
make px4_sitl gazebo_believer
```
- Before PR
Flight Log: https://logs.px4.io/plot_app?log=b38bb0ad-52ea-448d-b18f-425c6e8b24c6
![image](https://user-images.githubusercontent.com/5248102/147703278-9ffd26b8-544b-4bb7-bd82-1935f037a666.png)

- After PR
Flight Log: https://logs.px4.io/plot_app?log=7eba14da-5c0e-4d35-9770-da4c31254e9b
![image](https://user-images.githubusercontent.com/5248102/147703264-bbf69be8-5f27-4d15-90f1-0a679ce7ac41.png)

**Additional context**
- Fixes https://github.com/ethz-asl/ethzasl_fw_px4/issues/52