### PR TITLE
Add windshear plugin for dynamics soaring

### DIFF
--- a/ROMFS/px4fmu_common/init.d-posix/airframes/1038_plane_dynamicsoaring
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/1038_plane_dynamicsoaring
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+# @name Plane SITL
+#
+
+. ${R}etc/init.d/rc.fw_defaults
+
+if [ $AUTOCNF = yes ]
+then
+	param set EKF2_ARSP_THR 8
+	param set EKF2_FUSE_BETA 1
+	param set EKF2_MAG_ACCLIM 0
+	param set EKF2_MAG_YAWLIM 0
+
+	param set FW_LND_AIRSPD_SC 1
+	param set FW_LND_ANG 8
+	param set FW_THR_LND_MAX 0
+
+	param set FW_L1_PERIOD 12
+
+	param set FW_MAN_P_MAX 30
+
+	param set FW_PR_I 0.4
+	param set FW_PR_P 0.9
+	param set FW_PR_FF 0.2
+	param set FW_PSP_OFF 2
+	param set FW_P_LIM_MAX 32
+	param set FW_P_LIM_MIN -15
+
+	param set FW_RR_FF 0.1
+	param set FW_RR_P 0.3
+
+	param set FW_THR_MAX 0.6
+	param set FW_THR_MIN 0.05
+	param set FW_THR_CRUISE 0.25
+
+	param set FW_T_ALT_TC 2
+	param set FW_T_CLMB_MAX 8
+	param set FW_T_HRATE_FF 0.5
+	param set FW_T_SINK_MAX 2.7
+	param set FW_T_SINK_MIN 2.2
+	param set FW_T_TAS_TC 2
+
+	param set FW_W_EN 1
+
+	param set MIS_LTRMIN_ALT 30
+	param set MIS_TAKEOFF_ALT 30
+
+	param set NAV_ACC_RAD 15
+	param set NAV_DLL_ACT 2
+	param set NAV_LOITER_RAD 50
+
+	param set RWTO_TKOFF 1
+
+fi
+
+set MIXER_FILE etc/mixers-sitl/plane_sitl.main.mix
+set MIXER custom

--- a/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d-posix/airframes/CMakeLists.txt
@@ -63,6 +63,7 @@ px4_add_romfs_files(
 	1035_techpod
 	1036_malolo
 	1037_believer
+	1038_plane_dynamicsoaring
 	1040_standard_vtol
 	1041_tailsitter
 	1042_tiltrotor

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -140,6 +140,7 @@ set(models
 	plane_cam
 	plane_catapult
 	plane_lidar
+	plane_dynamicsoaring
 	r1_rover
 	rover
 	shell


### PR DESCRIPTION
**Describe problem solved by this pull request**
This PR adds a gazebo windshear plugin, which can be used to test dynamic soaring

Previously the wind plugin was a [world plugin](https://gazebosim.org/tutorials?tut=plugins_world) so that the same wind velocity is broadcast to all models in the gazebo world. For our purpose, the `gazebo_wind_shear_plugin` is added as a model plugin so that the wind strength can depend on the model pose.

**Describe your solution**
A specific SITL target with airframe `plane_dynamicsoaring` is created and can be run with the following command.
```
make px4_sitl gazebo_plane_dynamicsoaring
```

A linear wind gradient is implemented so that the wind gradient stays the same regardless of the altitude. We can extend this plugin to include more complicated wind plugins in the future.

The plugin can be configured with the [following parameters](https://github.com/PX4/PX4-SITL_gazebo/blob/bd23d366260abd893773456162650cf98a414111/models/plane_dynamicsoaring/plane_dynamicsoaring.sdf#L7-L20)

```
    <plugin name='wind_shear_plugin' filename='libgazebo_wind_shear_plugin.so'>
      <frameId>base_link</frameId>
      <robotNamespace/>
      <xyzOffset>1 0 0</xyzOffset>
      <windDirectionMean>0 1 0</windDirectionMean>
      <windVelocityMax>15.0</windVelocityMax>
      <windGustDirection>0 0 0</windGustDirection>
      <windGustDuration>0</windGustDuration>
      <windGustStart>0</windGustStart>
      <windGustVelocityMean>0</windGustVelocityMean>
      <windShearGradient>0.2</windShearGradient>
      <windShearOffset>0.0</windShearOffset>
      <windPubTopic>world_wind</windPubTopic>
    </plugin>
```
FYI @MarvinHarms

**Test data / coverage**
Tested in SITL Gazebo (flightlog: [log](https://review.px4.io/plot_app?log=fe12b871-5314-4ede-b558-85e1c9276317)), flying loiter circles at the same location with different altitudes. You can see the wind estimates varying depending on the altitude.

To reproduce: 
```
make px4_sitl gazebo_plane_dynamicsoaring
```


**Additional context**
- The wind field visualization is not present. This would require another visual plugin and will follow up with an additional PR